### PR TITLE
Using hostpath as storageclass

### DIFF
--- a/Kubernetes-Persistent-volume/PersistentV
+++ b/Kubernetes-Persistent-volume/PersistentV
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: demo-volume
+  labels:
+    type: local
+spec:
+  storageClassName: hostpath
+  capacity:
+    storage: 2Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: "/mnt/data"


### PR DESCRIPTION
[✅] We're using the host path as an example, although this is auto-configured to docker
[✅] 2Gi storage
[✅] Access R/WO only