### PR TITLE
Deploying docker image(go-lang-config) via deployment

### DIFF
--- a/Kubernetes-ConfigMap/deploy.yml
+++ b/Kubernetes-ConfigMap/deploy.yml
@@ -1,0 +1,48 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deploy-main
+  labels:
+    app: deploy-1
+    test: test
+spec:
+  selector:
+    matchLabels:
+      app: app-v1
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: app-v1
+    spec:
+      containers:
+      - name: example-app
+        image: mynameismohan/golang-app-readconfig:v1.0
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 5000
+        resources:
+          requests:
+            memory: "64Mi"
+            cpu: "50m"
+          limits:
+            memory: "256Mi"
+            cpu: "500m"
+      tolerations:
+      - key: "cattle.io/os"
+        value: "linux"
+        effect: "NoSchedule"      
+# `volumeMounts` section for configmap
+        volumeMounts:
+            - name: config-volume
+           mountPath: /configs/
+# `volumes` section for configmap 
+        volumes:
+          configMap:
+            name: app-v1-test-config #name of our configmap object


### PR DESCRIPTION
Deploying docker image(go-lang-config) via deploy.yaml

Workflow:

```
- Go app (Main.go)
- Build image
- Creating a Pod Deployment
   -  Kubernetes expects Config 
   -  Mounted via volume mount -> (This is done after we deploy a ConfigMap in k8s cluster) 
      then we can use it
```

