### PR TITLE
Deploying docker image(go-lang-config+secret) via deployment

### DIFF
--- a/Kubernetes-Secrets/deploy.yml
+++ b/Kubernetes-Secrets/deploy.yml
@@ -1,0 +1,54 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deploy-main
+  labels:
+    app: deploy-1
+    test: test
+spec:
+  selector:
+    matchLabels:
+      app: app-v1
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: app-v1
+    spec:
+      containers:
+      - name: example-app
+        image: mynameismohan/golang-app-readconfig:v1.0
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 5000
+        resources:
+          requests:
+            memory: "64Mi"
+            cpu: "50m"
+          limits:
+            memory: "256Mi"
+            cpu: "500m"
+      tolerations:
+      - key: "cattle.io/os"
+        value: "linux"
+        effect: "NoSchedule"      
+# `volumeMounts` section for configmap
+        volumeMounts:
+         - name: config-volume
+           mountPath: /configs/
+         - name: secret-volume
+           mountPath: /secrets/
+# `volumes` section for configmap 
+        volumes:
+        - name: secret-volume
+          secret:
+            secretName: app-v2-test-config #name of our secret object
+        - name: config-volume
+          configMap:
+            name: app-v1-test-config  

--- a/Kubernetes-Secrets/deploy.yml
+++ b/Kubernetes-Secrets/deploy.yml
@@ -4,13 +4,13 @@ kind: Deployment
 metadata:
   name: deploy-main
   labels:
-    app: deploy-1
+    app: deploy-2
     test: test
 spec:
   selector:
     matchLabels:
-      app: app-v1
-  replicas: 3
+      app: app-v2
+  replicas: 2
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -19,11 +19,11 @@ spec:
   template:
     metadata:
       labels:
-        app: app-v1
+        app: app-v2
     spec:
       containers:
       - name: example-app
-        image: mynameismohan/golang-app-readconfig:v1.0
+        image: mynameismohan/golang-app-conf-secrets
         imagePullPolicy: Always
         ports:
         - containerPort: 5000


### PR DESCRIPTION
Deploying docker image(go-lang-config+secret) via deploy.yaml

Workflow:

```
- Go app (Main.go)
- Build image
- Creating a Pod Deployment
   -  Kubernetes expects Config 
   -  Kubernetes expects Secret 
   -  Mounted via volume mount -> (This is done after we deploy a ConfigMap + Secret in k8s cluster) 
      then we can use it
```

